### PR TITLE
Added "keysEnum" attribute in @TermFacet annotation.

### DIFF
--- a/elasticsearch-annotations/src/main/java/org/elasticsearch/annotation/query/TermsFacet.java
+++ b/elasticsearch-annotations/src/main/java/org/elasticsearch/annotation/query/TermsFacet.java
@@ -4,7 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
+import org.elasticsearch.mapping.NoneEnumType;
 import org.elasticsearch.search.facet.terms.TermsFacet.ComparatorType;
 
 /**
@@ -21,11 +21,21 @@ import org.elasticsearch.search.facet.terms.TermsFacet.ComparatorType;
 @Target({ ElementType.FIELD, ElementType.METHOD })
 public @interface TermsFacet {
     /**
-     * The property sub-path if any.
+     * The property sub-path if any.<br>
+     * If {@link #keysEnum()} is provided, this will be used as property sub paths of the values of the map
+     * that will be used as terms.
      * 
      * @return The property sub path if any.
      */
     String[] paths() default "";
+
+    /**
+     * If dealing with a map (that will be stored as is), specified an Enum of keys you want to be a facet<br>
+     * This can be used in combination with {@link #paths()} if the values of the map are complex types
+     * 
+     * @return The property sub path if any.
+     */
+    Class<? extends Enum<?>> keysEnum() default NoneEnumType.class;
 
     /**
      * The number of terms to return
@@ -56,4 +66,5 @@ public @interface TermsFacet {
      * @return Array of terms that should be excluded from the terms facet request result.
      */
     String[] exclude() default {};
+
 }

--- a/elasticsearch-annotations/src/main/java/org/elasticsearch/mapping/NoneEnumType.java
+++ b/elasticsearch-annotations/src/main/java/org/elasticsearch/mapping/NoneEnumType.java
@@ -1,0 +1,4 @@
+package org.elasticsearch.mapping;
+
+public enum NoneEnumType {
+}


### PR DESCRIPTION
 This attribute defines an enum of keys to be used as facets when dealing with a map that is stored as is in elasticsearch. 
Therefore, the "paths" attributes will define the subpaths in the values of the map, if they are of complex types.